### PR TITLE
Adding last turn report to bottom of main game loop page

### DIFF
--- a/src/components/ShowRecentTurnsButton.tsx
+++ b/src/components/ShowRecentTurnsButton.tsx
@@ -10,25 +10,18 @@ import {
     Typography,
     useTheme,
 } from '@mui/material';
-import { GameStage, PlayerTurnResult } from '@types';
+import { GameStage } from '@types';
 import { useGameSessionContext } from '@context/GameSessionContext';
 
 import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
+import { useGetTurnResultText } from '@hooks/useGetTurnResultText';
 
 export const ShowRecentTurnsButton = () => {
     const theme = useTheme();
     const session = useGameSessionContext();
     const [showRecentTurns, setShowRecentTurns] = useState(false);
 
-    const getTurnResultText = (tr: PlayerTurnResult) => {
-        const player = session.players[tr.playerId].name;
-        if (tr.turnEntry.gotOnTheBoardThisTurn !== undefined) {
-            return `${player} ${
-                tr.turnEntry.gotOnTheBoardThisTurn ? 'Got' : "Didn't get"
-            } on the board.`;
-        }
-        return `${player} Earned: ${tr.turnEntry.earned} Total: ${tr.turnEntry.total}`;
-    };
+    const getTurnResultText = useGetTurnResultText();
 
     return (
         <>

--- a/src/components/game/MainGameLoop.tsx
+++ b/src/components/game/MainGameLoop.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
     Alert,
     Box,
@@ -14,12 +14,15 @@ import {
 import { useGameSessionContext } from '@context';
 import { Numpad, NumpadAction, PlayerAvatar, PlayerPlaceBadge, UndoLastTurnButton } from '@components';
 import { GameStage } from '@types';
+import { useGetTurnResultText } from '@hooks';
 
 export const MainGameLoop = () => {
     const theme = useTheme();
     const gameSession = useGameSessionContext();
+    const getTurnResultText = useGetTurnResultText();
     const currentPlayer = gameSession.players[gameSession.gameState.playersTurn];
     const [scoreAddition, setScoreAddition] = useState(0);
+    const [lastPlayersTurnResult, setLastPlayersTurnResult] = useState<string | undefined>();
 
     const onNumpadAction = useCallback(
         (value: number | NumpadAction) => {
@@ -90,6 +93,12 @@ export const MainGameLoop = () => {
     const currentWinner = useMemo(() => {
         if (gameSession.winnerId !== undefined) return gameSession.players[gameSession.winnerId];
     }, [gameSession.players, gameSession.winnerId]);
+
+    // Handles keeping the last turn result text up to date
+    useEffect(() => {
+        const lastTurnResult = gameSession.turnResults.at(-1);
+        if (lastTurnResult) setLastPlayersTurnResult(getTurnResultText(lastTurnResult));
+    }, [gameSession.turnResults, getTurnResultText]);
 
     return (
         <>
@@ -247,6 +256,9 @@ export const MainGameLoop = () => {
                         </Typography>
                     </Card>
                 )}
+                <Typography variant="h6" mt={0.5}>
+                    <i>{`Last turn: ${lastPlayersTurnResult}`}</i>
+                </Typography>
                 {/* TODO: Make a toast that alerts that someone surpassed or met the score goal */}
                 <Snackbar>
                     <Alert />

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './routerHooks';
+export * from './useGetTurnResultText';

--- a/src/hooks/useGetTurnResultText.ts
+++ b/src/hooks/useGetTurnResultText.ts
@@ -1,0 +1,19 @@
+import { useGameSessionContext } from '@context/GameSessionContext';
+import { PlayerTurnResult } from '@types';
+import { useCallback } from 'react';
+
+export const useGetTurnResultText = () => {
+    const session = useGameSessionContext();
+    return useCallback(
+        (tr: PlayerTurnResult) => {
+            const player = session.players[tr.playerId].name;
+            if (tr.turnEntry.gotOnTheBoardThisTurn !== undefined) {
+                return `${player} ${
+                    tr.turnEntry.gotOnTheBoardThisTurn ? 'Got' : "Didn't get"
+                } on the board.`;
+            }
+            return `${player} Earned: ${tr.turnEntry.earned} Total: ${tr.turnEntry.total}`;
+        },
+        [session.players]
+    );
+};

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -70,12 +70,12 @@ export const Rules = () => {
         return <GiDiceSixFacesSix size={theme.spacing(3)} />;
     }, [theme]);
     return (
-        <Stack>
+        <Stack display="flex" alignItems="center" justifyContent="center">
             <Typography
                 align="center"
                 variant="h2"
                 sx={{
-                    background: `-webkit-linear-gradient(45deg, #fb0, #f20 100%)`,
+                    background: `-webkit-linear-gradient(45deg, #fc3, #c00 100%)`,
                     WebkitBackgroundClip: 'text',
                     WebkitTextFillColor: 'transparent',
                     width: 'auto',
@@ -87,13 +87,13 @@ export const Rules = () => {
             <Divider sx={{ my: 1, borderBottomWidth: 4 }} />
             <Box my={1}>
                 <Typography variant="h4" align="center">
-                    <u>Initial Roll</u>
+                    <u>Who Rolls First?</u>
                 </Typography>
                 <NumberedListItem num={1}>
                     In order to decide whose turn it is first, each player must roll one die.
                 </NumberedListItem>
                 <NumberedListItem num={2}>
-                    The person with the highest role goes first. Players who tie re-roll.
+                    The person with the highest role goes first. Players who tie, re-roll.
                 </NumberedListItem>
             </Box>
             <Divider sx={{ mb: 1 }} />
@@ -102,28 +102,33 @@ export const Rules = () => {
                     <u>How to Play</u>
                 </Typography>
                 <Typography variant="h6" align="center">
-                    The game is broken up into three parts:
+                    The game is broken up into three main parts:
                 </Typography>
                 <List>
                     <NumberedListItem num={1}>
-                        <Stack>{`Getting "on the board".`}</Stack>
+                        <Stack>{`Getting "on the board" (eligable to score).`}</Stack>
                     </NumberedListItem>
-                    <NumberedListItem num={2}>Earning points.</NumberedListItem>
-                    <NumberedListItem num={3}>
-                        Getting to the score goal before everyone else.
-                    </NumberedListItem>
+                    <NumberedListItem
+                        num={2}
+                    >{`Earning points fast enough to be the first one "out" (reached or surpassed the score goal).`}</NumberedListItem>
+                    <NumberedListItem
+                        num={3}
+                    >{`Hoping no one beats your score on their last turn. Or if you're the one behind, 
+                    try to beat the score leader with one last triumphant turn!`}</NumberedListItem>
                 </List>
+            </Box>
+            <Box my={1}>
                 <Typography variant="h5" align="center">
                     <u>{`Getting "on the board"`}</u>
                 </Typography>
-                <BulletPoint>{`Before a player can score, the must first get "on the board".`}</BulletPoint>
+                <BulletPoint>{`Before a player can score, they must first get "on the board".`}</BulletPoint>
                 <BulletPoint>
                     To do this, you must surpass a certain point threshold within one turn. The default
                     threshold is <u>500</u> points.
                 </BulletPoint>
                 <BulletPoint>
                     {`The player doesn't get to keep the points they earned to get on the board. But on 
-                    their next turn they'll now be eligible to score.`}
+                    their next turn they'll now be eligible to score!`}
                 </BulletPoint>
                 <Typography variant="h5" align="center" mt={2}>
                     <u>Earning Points</u>
@@ -141,18 +146,30 @@ export const Rules = () => {
                     remaining dice hoping for another scoring roll.
                 </BulletPoint>
                 <BulletPoint>
-                    {`If at any point you don't score anything on a roll, then you do NOT keep 
-                    the points you've earned up to that point and your turn is over.`}
+                    {`If you end up with all five dice aside and nothing to roll, then you get to roll
+                    all five dice again and keep going!`}
                 </BulletPoint>
                 <BulletPoint>
-                    {`If your roll is scoring, or contains pairs of dice (ex: you roll three 
-                    remaining dice and get a one and two fours) then you can pick up all five dice, 
-                    keep your score, and roll them all again. If however, you instead rolled two ones 
-                    and a four, then you can only choose to roll the one remaining die.`}
+                    <u>IMPORTANT:</u> Another way to keep your turn going{' '}
+                    <b>without rolling anything scoring</b> is to roll mathcing dice! For example, if
+                    you have two dice left to roll and you roll a matching pair, then you get to roll
+                    all five dice again and keep your turn alive!
+                </BulletPoint>
+                <BulletPoint>
+                    {`You can keep doing this until you either decide to end your turn and keep the 
+                    points you've earned that turn, or you fail to roll anything scoring or matching 
+                    and lose all the points you've earned on that turn. Just remember the story of 
+                    Icarus and don't get too greedy! ;)`}
                 </BulletPoint>
                 <Typography variant="h5" align="center" mt={2}>
                     <u>{`Getting to the Score Goal`}</u>
                 </Typography>
+                <BulletPoint>
+                    {`The goal of the game is to reach the score goal before everyone else! If after 
+                    you've ended your turn you have supassed or met the score goal, you're considered
+                    "out" and now get to watch everyone else roll one last time in a desperate attempt
+                    to catch up and beat you at the very last minute!`}
+                </BulletPoint>
                 <Typography variant="h5" align="center" mt={2}>
                     <u>{`Scoring Rolls`}</u>
                 </Typography>


### PR DESCRIPTION
# What's new?
- **Adding last turn report to bottom of main game loop page**
- Adding new hook to handle turn log creation
- Editing Rules page to include more straight forward wording Fixed small css bug in gradient on Rules page
- Fixed small css bug in gradient on Rules page

## Preview
<img width="803" alt="Screenshot 2023-06-04 at 12 56 03 AM" src="https://github.com/FoxtrotPerry/dice-game/assets/31854658/9fff4185-74b3-4980-8f17-a0f193c1101f">